### PR TITLE
Issues/dart2js runtime

### DIFF
--- a/packages/crdt_lf/CHANGELOG.md
+++ b/packages/crdt_lf/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## [3.2.1](https://github.com/MattiaPispisa/crdt/tree/crdt_lf-v3.2.1/packages/crdt_lf)
 
-**Date:** 2026-06-26
+**Date:** 2026-06-27
 
 [compare to previous release](https://github.com/MattiaPispisa/crdt/compare/crdt_lf-v3.2.0...crdt_lf-v3.2.1)
 

--- a/packages/crdt_lf/CHANGELOG.md
+++ b/packages/crdt_lf/CHANGELOG.md
@@ -1,3 +1,13 @@
+## [3.2.1](https://github.com/MattiaPispisa/crdt/tree/crdt_lf-v3.2.1/packages/crdt_lf)
+
+**Date:** 2026-06-26
+
+[compare to previous release](https://github.com/MattiaPispisa/crdt/compare/crdt_lf-v3.2.0...crdt_lf-v3.2.1)
+
+### Fixed
+
+- Nested handlers failed to reconstruct (and therefore to sync) in dart2js-minified builds (e.g. Flutter web `--release`), because handler type identity relied on `runtimeType.toString()` (an opaque `"minified:..."` token there). Introduced the stable `Handler.handlerType` tag used for routing, snapshot manifest, `HandlerRef`s and factory keys — defaults to `runtimeType.toString()` (non-breaking), overridden with a constant by built-in handlers, with an optional `handlerType` constructor argument for generic handlers.
+
 ## [3.2.0](https://github.com/MattiaPispisa/crdt/tree/crdt_lf-v3.2.0/packages/crdt_lf)
 
 **Date:** 2026-06-25

--- a/packages/crdt_lf/flutter_example/lib/examples/document/_state.dart
+++ b/packages/crdt_lf/flutter_example/lib/examples/document/_state.dart
@@ -46,6 +46,12 @@ class DocumentState extends ExampleDocument<CRDTMovableListRefHandler> {
   static const _kBlocksKey = 'blocks';
   static const _kDoneKey = 'done';
 
+  // Stable type tag for the todo `done` register. Used both as the factory key
+  // and as the handler's `handlerType`, so the two match even in a minified
+  // (Flutter web `--release`) build where `runtimeType.toString()` would be an
+  // opaque `"minified:..."` token. See [Handler.handlerType].
+  static const _kDoneType = 'CRDTRegisterHandler<bool>';
+
   @override
   CRDTMovableListRefHandler createHandler(BaseCRDTDocument doc) {
     // Register the factories so children received from a remote peer (or a
@@ -53,12 +59,11 @@ class DocumentState extends ExampleDocument<CRDTMovableListRefHandler> {
     doc.registerDefaultFactories();
     // The todo `done` flag is a nested CRDTRegisterHandler<bool> (a LWW
     // register), which is generic and therefore not part of the default
-    // (non-generic) set, so register it explicitly. The factory is keyed by the
-    // handler's runtime type string; that is stable for this example app (a
-    // minified build would need a non-generic wrapper instead).
+    // (non-generic) set, so register it explicitly — with the same stable tag
+    // the handler is created with below.
     doc.registerFactory(
-      'CRDTRegisterHandler<bool>',
-      CRDTRegisterHandler<bool>.new,
+      _kDoneType,
+      (d, id) => CRDTRegisterHandler<bool>(d, id, handlerType: _kDoneType),
     );
     return CRDTMovableListRefHandler(doc, _kDocumentId);
   }
@@ -244,7 +249,11 @@ class DocumentState extends ExampleDocument<CRDTMovableListRefHandler> {
   }
 
   CRDTRegisterHandler<bool> _newDone({required bool value}) {
-    final handler = CRDTRegisterHandler<bool>(document, _newId());
+    final handler = CRDTRegisterHandler<bool>(
+      document,
+      _newId(),
+      handlerType: _kDoneType,
+    );
     handler.set(value);
     return handler;
   }

--- a/packages/crdt_lf/lib/crdt_lf.dart
+++ b/packages/crdt_lf/lib/crdt_lf.dart
@@ -17,7 +17,6 @@ export 'src/handler/fugue_list/handler.dart';
 export 'src/handler/fugue_movable_list/handler.dart';
 export 'src/handler/fugue_text/handler.dart';
 export 'src/handler/handler.dart';
-export 'src/handler/handler_type.dart';
 export 'src/handler/list/handler.dart';
 export 'src/handler/list_ref/handler.dart';
 export 'src/handler/map/handler.dart';

--- a/packages/crdt_lf/lib/crdt_lf.dart
+++ b/packages/crdt_lf/lib/crdt_lf.dart
@@ -17,6 +17,7 @@ export 'src/handler/fugue_list/handler.dart';
 export 'src/handler/fugue_movable_list/handler.dart';
 export 'src/handler/fugue_text/handler.dart';
 export 'src/handler/handler.dart';
+export 'src/handler/handler_type.dart';
 export 'src/handler/list/handler.dart';
 export 'src/handler/list_ref/handler.dart';
 export 'src/handler/map/handler.dart';

--- a/packages/crdt_lf/lib/src/devtools/devtools.dart
+++ b/packages/crdt_lf/lib/src/devtools/devtools.dart
@@ -110,7 +110,7 @@ String describeDocumentJson(int trackedId) {
       .map(
         (entry) => {
           'id': entry.key,
-          'type': entry.value.runtimeType.toString(),
+          'type': entry.value.handlerType,
           'value': entry.value.toString(),
         },
       )

--- a/packages/crdt_lf/lib/src/document.dart
+++ b/packages/crdt_lf/lib/src/document.dart
@@ -100,7 +100,7 @@ abstract class BaseCRDTDocument {
   /// ```
   final Map<String, HandlerFactory> _factories = {};
 
-  /// Registers a [HandlerFactory] for handlers whose `runtimeType.toString()`
+  /// Registers a [HandlerFactory] for handlers whose [Handler.handlerType]
   /// equals [type]. Registering the same [type] twice overwrites the factory.
   void registerFactory(String type, HandlerFactory factory) {
     _factories[type] = factory;
@@ -792,7 +792,7 @@ class CRDTDocument extends BaseCRDTDocument {
     if (hasContainers) {
       state[_handlerManifestKey] = _encodeHandlerManifest({
         for (final provider in _handlers.values)
-          provider.id: provider.runtimeType.toString(),
+          provider.id: provider.handlerType,
       });
     }
     final snapshot = Snapshot.create(
@@ -1697,7 +1697,7 @@ extension _HandlerHelper on Handler<dynamic> {
 
   Uint8List _buildPrefix() {
     final out = BytesBuilder(copy: false);
-    final typeBytes = utf8.encode(runtimeType.toString());
+    final typeBytes = utf8.encode(handlerType);
     UVarint.write(typeBytes.length, out);
     out.add(typeBytes);
     final idBytes = utf8.encode(id);

--- a/packages/crdt_lf/lib/src/handler/fugue/fugue_sequence_handler.dart
+++ b/packages/crdt_lf/lib/src/handler/fugue/fugue_sequence_handler.dart
@@ -64,7 +64,7 @@ class FugueState<T, V> {
 abstract class FugueSequenceHandler<T, V, S extends FugueState<T, V>>
     extends Handler<S> with FugueCache<S> {
   /// Creates a Fugue sequence handler bound to [doc] with the given [id].
-  FugueSequenceHandler(super.doc, String id) : _id = id;
+  FugueSequenceHandler(super.doc, String id, {super.handlerType}) : _id = id;
 
   final String _id;
 

--- a/packages/crdt_lf/lib/src/handler/fugue_list/handler.dart
+++ b/packages/crdt_lf/lib/src/handler/fugue_list/handler.dart
@@ -40,6 +40,7 @@ class CRDTFugueListHandler<T>
     super.doc,
     super.id, {
     ValueCodec<T>? valueCodec,
+    super.handlerType,
   }) : _valueCodec = valueCodec ?? JsonValueCodec<T>();
 
   final ValueCodec<T> _valueCodec;

--- a/packages/crdt_lf/lib/src/handler/fugue_list/operation.dart
+++ b/packages/crdt_lf/lib/src/handler/fugue_list/operation.dart
@@ -15,7 +15,7 @@ class _FugueListOperationFactory<T> {
       return null;
     }
 
-    if (env.handlerType != handler.runtimeType.toString()) {
+    if (env.handlerType != handler.handlerType) {
       return null;
     }
 

--- a/packages/crdt_lf/lib/src/handler/fugue_movable_list/handler.dart
+++ b/packages/crdt_lf/lib/src/handler/fugue_movable_list/handler.dart
@@ -47,6 +47,7 @@ class CRDTFugueMovableListHandler<T> extends Handler<FugueMovableListState<T>>
     super.doc,
     String id, {
     ValueCodec<T>? valueCodec,
+    super.handlerType,
   })  : _id = id,
         _valueCodec = valueCodec ?? JsonValueCodec<T>();
 

--- a/packages/crdt_lf/lib/src/handler/fugue_movable_list/operation.dart
+++ b/packages/crdt_lf/lib/src/handler/fugue_movable_list/operation.dart
@@ -12,7 +12,7 @@ class _FugueMovableListOperationFactory<T> {
     if (env.handlerId != handler.id) {
       return null;
     }
-    if (env.handlerType != handler.runtimeType.toString()) {
+    if (env.handlerType != handler.handlerType) {
       return null;
     }
 

--- a/packages/crdt_lf/lib/src/handler/fugue_text/handler.dart
+++ b/packages/crdt_lf/lib/src/handler/fugue_text/handler.dart
@@ -32,7 +32,7 @@ class CRDTFugueTextHandler
 
   /// Stable type tag (minification-safe). See [Handler.handlerType].
   @override
-  String get handlerType => 'CRDTFugueTextHandler';
+  String get handlerType => kFugueTextHandlerType;
 
   @override
   late final OperationFactory operationFactory =

--- a/packages/crdt_lf/lib/src/handler/fugue_text/handler.dart
+++ b/packages/crdt_lf/lib/src/handler/fugue_text/handler.dart
@@ -30,6 +30,10 @@ class CRDTFugueTextHandler
   /// Constructor that initializes a new Fugue text handler
   CRDTFugueTextHandler(super.doc, super.id);
 
+  /// Stable type tag (minification-safe). See [Handler.handlerType].
+  @override
+  String get handlerType => 'CRDTFugueTextHandler';
+
   @override
   late final OperationFactory operationFactory =
       _FugueTextOperationFactory(this).fromBytes;

--- a/packages/crdt_lf/lib/src/handler/fugue_text/handler.dart
+++ b/packages/crdt_lf/lib/src/handler/fugue_text/handler.dart
@@ -3,6 +3,7 @@ import 'dart:typed_data';
 
 import 'package:crdt_lf/crdt_lf.dart';
 import 'package:crdt_lf/src/handler/fugue/fugue_sequence_handler.dart';
+import 'package:crdt_lf/src/handler/handler_type.dart';
 
 part 'operation.dart';
 

--- a/packages/crdt_lf/lib/src/handler/fugue_text/operation.dart
+++ b/packages/crdt_lf/lib/src/handler/fugue_text/operation.dart
@@ -15,7 +15,7 @@ class _FugueTextOperationFactory {
       return null;
     }
 
-    if (env.handlerType != handler.runtimeType.toString()) {
+    if (env.handlerType != handler.handlerType) {
       return null;
     }
 

--- a/packages/crdt_lf/lib/src/handler/handler.dart
+++ b/packages/crdt_lf/lib/src/handler/handler.dart
@@ -13,16 +13,35 @@ typedef OperationFactory = Operation? Function(
 /// data structure in the CRDT system.
 abstract class Handler<T>
     with DocumentConsumer, SnapshotProvider, CacheableStateProvider<T> {
-  /// Creates a new handler for the given document
-  Handler(this.doc) {
+  /// Creates a new handler for the given document.
+  ///
+  /// [handlerType] optionally overrides the type tag (see [handlerType]); pass
+  /// a stable constant for generic handlers that must work in a minified build.
+  Handler(this.doc, {String? handlerType}) : _handlerType = handlerType {
     doc.registerHandler(this);
   }
 
   /// The document that owns this handler
   final BaseCRDTDocument doc;
 
+  final String? _handlerType;
+
   /// The factory function that creates an operation from a payload
   OperationFactory get operationFactory;
+
+  /// Stable identifier of this handler's **type**.
+  ///
+  /// Used as the type tag in operation envelopes, in the snapshot handler
+  /// manifest and in [HandlerRef]s, and as the key under which a
+  /// [HandlerFactory] is registered (see [BaseCRDTDocument.registerFactory]).
+  /// The same value is produced on every peer so changes route to the matching
+  /// handler and nested handlers can be reconstructed remotely.
+  ///
+  /// Defaults to `runtimeType.toString()`, which is convenient but **not
+  /// stable under dart2js minification**. Custom handlers
+  /// that must work in a minified build (or persist/sync across builds) should
+  /// override it with their own constant, or pass one to the constructor.
+  String get handlerType => _handlerType ?? runtimeType.toString();
 
   /// Cached insert type instances for this handler, used in operations.
   late final OperationType insertType = OperationType.insert(this);

--- a/packages/crdt_lf/lib/src/handler/handler.dart
+++ b/packages/crdt_lf/lib/src/handler/handler.dart
@@ -15,8 +15,10 @@ abstract class Handler<T>
     with DocumentConsumer, SnapshotProvider, CacheableStateProvider<T> {
   /// Creates a new handler for the given document.
   ///
-  /// [handlerType] optionally overrides the type tag (see [handlerType]); pass
-  /// a stable constant for generic handlers that must work in a minified build.
+  /// [handlerType] optionally overrides the type tag
+  /// (see [Handler.handlerType]);
+  /// pass a stable constant for generic handlers
+  /// that must work in a minified build.
   Handler(this.doc, {String? handlerType}) : _handlerType = handlerType {
     doc.registerHandler(this);
   }

--- a/packages/crdt_lf/lib/src/handler/handler_type.dart
+++ b/packages/crdt_lf/lib/src/handler/handler_type.dart
@@ -1,0 +1,19 @@
+// Stable Handler.handlerType tags for the built-in container
+// and handlers.
+
+import 'package:crdt_lf/crdt_lf.dart';
+
+/// Type tag of [CRDTMapRefHandler].
+const kMapRefHandlerType = 'CRDTMapRefHandler';
+
+/// Type tag of [CRDTListRefHandler].
+const kListRefHandlerType = 'CRDTListRefHandler';
+
+/// Type tag of [CRDTMovableListRefHandler].
+const kMovableListRefHandlerType = 'CRDTMovableListRefHandler';
+
+/// Type tag of [CRDTTextHandler].
+const kTextHandlerType = 'CRDTTextHandler';
+
+/// Type tag of [CRDTFugueTextHandler].
+const kFugueTextHandlerType = 'CRDTFugueTextHandler';

--- a/packages/crdt_lf/lib/src/handler/list/handler.dart
+++ b/packages/crdt_lf/lib/src/handler/list/handler.dart
@@ -30,6 +30,7 @@ class CRDTListHandler<T> extends Handler<List<T>> {
     super.doc,
     this._id, {
     ValueCodec<T>? valueCodec,
+    super.handlerType,
   }) : _valueCodec = valueCodec ?? JsonValueCodec<T>();
 
   @override

--- a/packages/crdt_lf/lib/src/handler/list/operation.dart
+++ b/packages/crdt_lf/lib/src/handler/list/operation.dart
@@ -10,7 +10,7 @@ class _ListOperationFactory<T> {
       return null;
     }
 
-    if (env.handlerType != handler.runtimeType.toString()) {
+    if (env.handlerType != handler.handlerType) {
       return null;
     }
 

--- a/packages/crdt_lf/lib/src/handler/list_ref/handler.dart
+++ b/packages/crdt_lf/lib/src/handler/list_ref/handler.dart
@@ -28,7 +28,7 @@ class CRDTListRefHandler extends CRDTFugueListHandler<HandlerRef>
 
   /// Stable type tag (minification-safe). See [Handler.handlerType].
   @override
-  String get handlerType => 'CRDTListRefHandler';
+  String get handlerType => kListRefHandlerType;
 
   /// Inserts a reference to [handler] at position [index].
   ///

--- a/packages/crdt_lf/lib/src/handler/list_ref/handler.dart
+++ b/packages/crdt_lf/lib/src/handler/list_ref/handler.dart
@@ -1,4 +1,5 @@
 import 'package:crdt_lf/crdt_lf.dart';
+import 'package:crdt_lf/src/handler/handler_type.dart';
 
 /// # CRDT ordered list of references
 ///

--- a/packages/crdt_lf/lib/src/handler/list_ref/handler.dart
+++ b/packages/crdt_lf/lib/src/handler/list_ref/handler.dart
@@ -26,6 +26,10 @@ class CRDTListRefHandler extends CRDTFugueListHandler<HandlerRef>
   CRDTListRefHandler(super.doc, super.id)
       : super(valueCodec: const HandlerRefCodec());
 
+  /// Stable type tag (minification-safe). See [Handler.handlerType].
+  @override
+  String get handlerType => 'CRDTListRefHandler';
+
   /// Inserts a reference to [handler] at position [index].
   ///
   /// {@template handlers_in_ref}

--- a/packages/crdt_lf/lib/src/handler/map/handler.dart
+++ b/packages/crdt_lf/lib/src/handler/map/handler.dart
@@ -35,6 +35,7 @@ class CRDTMapHandler<T> extends Handler<Map<String, T>> {
     super.doc,
     this._id, {
     ValueCodec<T>? valueCodec,
+    super.handlerType,
   }) : _valueCodec = valueCodec ?? JsonValueCodec<T>();
 
   /// The ID of this map in the document

--- a/packages/crdt_lf/lib/src/handler/map/operation.dart
+++ b/packages/crdt_lf/lib/src/handler/map/operation.dart
@@ -10,7 +10,7 @@ class _MapOperationFactory<T> {
       return null;
     }
 
-    if (env.handlerType != handler.runtimeType.toString()) {
+    if (env.handlerType != handler.handlerType) {
       return null;
     }
 

--- a/packages/crdt_lf/lib/src/handler/map_ref/handler.dart
+++ b/packages/crdt_lf/lib/src/handler/map_ref/handler.dart
@@ -1,4 +1,5 @@
 import 'package:crdt_lf/crdt_lf.dart';
+import 'package:crdt_lf/src/handler/handler_type.dart';
 
 /// # CRDT Map of references
 ///

--- a/packages/crdt_lf/lib/src/handler/map_ref/handler.dart
+++ b/packages/crdt_lf/lib/src/handler/map_ref/handler.dart
@@ -27,7 +27,7 @@ class CRDTMapRefHandler extends CRDTMapHandler<HandlerRef>
 
   /// Stable type tag (minification-safe). See [Handler.handlerType].
   @override
-  String get handlerType => 'CRDTMapRefHandler';
+  String get handlerType => kMapRefHandlerType;
 
   /// Associates [key] with a reference to [handler].
   ///

--- a/packages/crdt_lf/lib/src/handler/map_ref/handler.dart
+++ b/packages/crdt_lf/lib/src/handler/map_ref/handler.dart
@@ -25,6 +25,10 @@ class CRDTMapRefHandler extends CRDTMapHandler<HandlerRef>
   CRDTMapRefHandler(super.doc, super.id)
       : super(valueCodec: const HandlerRefCodec());
 
+  /// Stable type tag (minification-safe). See [Handler.handlerType].
+  @override
+  String get handlerType => 'CRDTMapRefHandler';
+
   /// Associates [key] with a reference to [handler].
   ///
   /// {@macro handlers_in_ref}

--- a/packages/crdt_lf/lib/src/handler/movable_list_ref/handler.dart
+++ b/packages/crdt_lf/lib/src/handler/movable_list_ref/handler.dart
@@ -24,6 +24,10 @@ class CRDTMovableListRefHandler extends CRDTFugueMovableListHandler<HandlerRef>
   CRDTMovableListRefHandler(super.doc, super.id)
       : super(valueCodec: const HandlerRefCodec());
 
+  /// Stable type tag (minification-safe). See [Handler.handlerType].
+  @override
+  String get handlerType => 'CRDTMovableListRefHandler';
+
   /// Inserts a reference to [handler] at position [index].
   ///
   /// {@macro handlers_in_ref}

--- a/packages/crdt_lf/lib/src/handler/movable_list_ref/handler.dart
+++ b/packages/crdt_lf/lib/src/handler/movable_list_ref/handler.dart
@@ -1,4 +1,5 @@
 import 'package:crdt_lf/crdt_lf.dart';
+import 'package:crdt_lf/src/handler/handler_type.dart';
 
 /// # CRDT movable ordered list of references
 ///

--- a/packages/crdt_lf/lib/src/handler/movable_list_ref/handler.dart
+++ b/packages/crdt_lf/lib/src/handler/movable_list_ref/handler.dart
@@ -26,7 +26,7 @@ class CRDTMovableListRefHandler extends CRDTFugueMovableListHandler<HandlerRef>
 
   /// Stable type tag (minification-safe). See [Handler.handlerType].
   @override
-  String get handlerType => 'CRDTMovableListRefHandler';
+  String get handlerType => kMovableListRefHandlerType;
 
   /// Inserts a reference to [handler] at position [index].
   ///

--- a/packages/crdt_lf/lib/src/handler/or_map/handler.dart
+++ b/packages/crdt_lf/lib/src/handler/or_map/handler.dart
@@ -39,6 +39,7 @@ class CRDTORMapHandler<K, V> extends Handler<ORMapState<K, V>> {
     this._id, {
     ValueCodec<K>? keyCodec,
     ValueCodec<V>? valueCodec,
+    super.handlerType,
   })  : _keyCodec = keyCodec ?? JsonValueCodec<K>(),
         _valueCodec = valueCodec ?? JsonValueCodec<V>();
 

--- a/packages/crdt_lf/lib/src/handler/or_map/operation.dart
+++ b/packages/crdt_lf/lib/src/handler/or_map/operation.dart
@@ -10,7 +10,7 @@ class _ORMapOperationFactory<K, V> {
       return null;
     }
 
-    if (env.handlerType != handler.runtimeType.toString()) {
+    if (env.handlerType != handler.handlerType) {
       return null;
     }
 

--- a/packages/crdt_lf/lib/src/handler/or_set/handler.dart
+++ b/packages/crdt_lf/lib/src/handler/or_set/handler.dart
@@ -37,6 +37,7 @@ class CRDTORSetHandler<T> extends Handler<ORSetState<T>> {
     super.doc,
     this._id, {
     ValueCodec<T>? valueCodec,
+    super.handlerType,
   }) : _valueCodec = valueCodec ?? JsonValueCodec<T>();
 
   final String _id;

--- a/packages/crdt_lf/lib/src/handler/or_set/operation.dart
+++ b/packages/crdt_lf/lib/src/handler/or_set/operation.dart
@@ -10,7 +10,7 @@ class _ORSetOperationFactory<T> {
       return null;
     }
 
-    if (env.handlerType != handler.runtimeType.toString()) {
+    if (env.handlerType != handler.handlerType) {
       return null;
     }
 

--- a/packages/crdt_lf/lib/src/handler/ref/handler_ref.dart
+++ b/packages/crdt_lf/lib/src/handler/ref/handler_ref.dart
@@ -110,14 +110,11 @@ abstract class ContainerHandler {
 extension RegisterDefaultFactories on BaseCRDTDocument {
   /// Registers the built-in container and non-generic leaf factories.
   void registerDefaultFactories() {
-    registerFactory('CRDTMapRefHandler', CRDTMapRefHandler.new);
-    registerFactory('CRDTListRefHandler', CRDTListRefHandler.new);
-    registerFactory(
-      'CRDTMovableListRefHandler',
-      CRDTMovableListRefHandler.new,
-    );
-    registerFactory('CRDTTextHandler', CRDTTextHandler.new);
-    registerFactory('CRDTFugueTextHandler', CRDTFugueTextHandler.new);
+    registerFactory(kMapRefHandlerType, CRDTMapRefHandler.new);
+    registerFactory(kListRefHandlerType, CRDTListRefHandler.new);
+    registerFactory(kMovableListRefHandlerType, CRDTMovableListRefHandler.new);
+    registerFactory(kTextHandlerType, CRDTTextHandler.new);
+    registerFactory(kFugueTextHandlerType, CRDTFugueTextHandler.new);
   }
 }
 

--- a/packages/crdt_lf/lib/src/handler/ref/handler_ref.dart
+++ b/packages/crdt_lf/lib/src/handler/ref/handler_ref.dart
@@ -20,7 +20,7 @@ typedef HandlerFactory = Handler<dynamic> Function(
 /// raw data, keeping the document storage **flat**: every handler lives in the
 /// document registry keyed by its [id], and a parent points to a child by id.
 ///
-/// The [type] is the child handler's `runtimeType.toString()`, which is the key
+/// The [type] is the child handler's [Handler.handlerType], which is the key
 /// used to look up a [HandlerFactory] when reconstructing the tree on a remote
 /// peer.
 class HandlerRef {
@@ -29,12 +29,14 @@ class HandlerRef {
 
   /// Builds a reference pointing at [handler].
   factory HandlerRef.of(Handler<dynamic> handler) =>
-      HandlerRef(handler.id, handler.runtimeType.toString());
+      HandlerRef(handler.id, handler.handlerType);
 
   /// The referenced handler's unique id.
   final String id;
 
-  /// The referenced handler's runtime type (factory key).
+  /// The referenced handler's type tag (factory key).
+  ///
+  /// See [Handler.handlerType].
   final String type;
 
   @override

--- a/packages/crdt_lf/lib/src/handler/ref/handler_ref.dart
+++ b/packages/crdt_lf/lib/src/handler/ref/handler_ref.dart
@@ -2,6 +2,7 @@ import 'dart:convert';
 import 'dart:typed_data';
 
 import 'package:crdt_lf/crdt_lf.dart';
+import 'package:crdt_lf/src/handler/handler_type.dart';
 
 /// A factory that instantiates a [Handler] of a specific runtime type for a
 /// given [BaseCRDTDocument] and handler id.

--- a/packages/crdt_lf/lib/src/handler/register/handler.dart
+++ b/packages/crdt_lf/lib/src/handler/register/handler.dart
@@ -32,6 +32,7 @@ class CRDTRegisterHandler<T> extends Handler<T> {
     super.doc,
     this._id, {
     ValueCodec<T>? valueCodec,
+    super.handlerType,
   }) : _valueCodec = valueCodec ?? JsonValueCodec<T>();
 
   final String _id;

--- a/packages/crdt_lf/lib/src/handler/register/operation.dart
+++ b/packages/crdt_lf/lib/src/handler/register/operation.dart
@@ -10,7 +10,7 @@ class _RegisterOperationFactory<T> {
     if (env.handlerId != handler.id) {
       return null;
     }
-    if (env.handlerType != handler.runtimeType.toString()) {
+    if (env.handlerType != handler.handlerType) {
       return null;
     }
 

--- a/packages/crdt_lf/lib/src/handler/text/handler.dart
+++ b/packages/crdt_lf/lib/src/handler/text/handler.dart
@@ -36,7 +36,7 @@ class CRDTTextHandler extends Handler<String> {
 
   /// Stable type tag (minification-safe). See [Handler.handlerType].
   @override
-  String get handlerType => 'CRDTTextHandler';
+  String get handlerType => kTextHandlerType;
 
   @override
   late final OperationFactory operationFactory =

--- a/packages/crdt_lf/lib/src/handler/text/handler.dart
+++ b/packages/crdt_lf/lib/src/handler/text/handler.dart
@@ -3,6 +3,7 @@ import 'dart:math';
 import 'dart:typed_data';
 
 import 'package:crdt_lf/crdt_lf.dart';
+import 'package:crdt_lf/src/handler/handler_type.dart';
 
 part 'operation.dart';
 

--- a/packages/crdt_lf/lib/src/handler/text/handler.dart
+++ b/packages/crdt_lf/lib/src/handler/text/handler.dart
@@ -34,6 +34,10 @@ class CRDTTextHandler extends Handler<String> {
   @override
   String get id => _id;
 
+  /// Stable type tag (minification-safe). See [Handler.handlerType].
+  @override
+  String get handlerType => 'CRDTTextHandler';
+
   @override
   late final OperationFactory operationFactory =
       _TextOperationFactory(this).fromBytes;

--- a/packages/crdt_lf/lib/src/handler/text/operation.dart
+++ b/packages/crdt_lf/lib/src/handler/text/operation.dart
@@ -10,7 +10,7 @@ class _TextOperationFactory {
       return null;
     }
 
-    if (env.handlerType != handler.runtimeType.toString()) {
+    if (env.handlerType != handler.handlerType) {
       return null;
     }
 

--- a/packages/crdt_lf/lib/src/operation/type.dart
+++ b/packages/crdt_lf/lib/src/operation/type.dart
@@ -18,7 +18,7 @@ class OperationType {
   /// Insert operation
   factory OperationType.insert(Handler<dynamic> handler) {
     return OperationType._(
-      handler: handler.runtimeType.toString(),
+      handler: handler.handlerType,
       type: _insert,
     );
   }
@@ -26,7 +26,7 @@ class OperationType {
   /// Delete operation
   factory OperationType.delete(Handler<dynamic> handler) {
     return OperationType._(
-      handler: handler.runtimeType.toString(),
+      handler: handler.handlerType,
       type: _delete,
     );
   }
@@ -34,7 +34,7 @@ class OperationType {
   /// Update operation
   factory OperationType.update(Handler<dynamic> handler) {
     return OperationType._(
-      handler: handler.runtimeType.toString(),
+      handler: handler.handlerType,
       type: _update,
     );
   }
@@ -43,7 +43,7 @@ class OperationType {
   /// without changing their identity (e.g. `CRDTFugueMovableListHandler`).
   factory OperationType.move(Handler<dynamic> handler) {
     return OperationType._(
-      handler: handler.runtimeType.toString(),
+      handler: handler.handlerType,
       type: _move,
     );
   }

--- a/packages/crdt_lf/pubspec.yaml
+++ b/packages/crdt_lf/pubspec.yaml
@@ -4,7 +4,7 @@ homepage: https://mattiapispisa.github.io/
 repository: https://github.com/MattiaPispisa/crdt/tree/main/packages/crdt_lf
 topics: [crdt, local-first, fugue, hlc]
 
-version: 3.2.0
+version: 3.2.1
 
 environment:
   sdk: ">=2.17.0 <4.0.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,6 +4,6 @@ environment:
   sdk: ">=2.17.0 <4.0.0"
 
 dev_dependencies:
+  en_logger: ^2.0.0
   melos: ^6.3.2
   path: ^1.9.0
-  en_logger: ^2.0.0


### PR DESCRIPTION
Nested handlers failed to reconstruct (and therefore to sync) in dart2js-minified builds.

**Result**:
- The default `registerFactory` methods do not work on the web. The keys under which they are registered differ from the runtimeType on the web.
- Synchronization between nested CRDTs created on different platforms (web and IO) does not work.