### PR TITLE
Hotfix/crdt lf flutter identical character caret

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -14,13 +14,6 @@
       ]
     },
     {
-      "name": "🐕 🐦 greyhound_markdown (local server)",
-      "cwd": "apps/greyhound_markdown/client",
-      "request": "launch",
-      "type": "dart",
-      "args": []
-    },
-    {
       "name": "[crdt_lf] flutter_example",
       "cwd": "packages/crdt_lf/flutter_example",
       "request": "launch",

--- a/packages/crdt_lf/CHANGELOG.md
+++ b/packages/crdt_lf/CHANGELOG.md
@@ -2,13 +2,10 @@
 
 ### Fixed
 
-- Reading a large document no longer risks a stack overflow. The Fugue tree's
-  in-order traversal (behind `value`/`nodes`, and the index rebuild on
-  deserialization) was recursive, so a long run of consecutive inserts — e.g.
-  pasting a big block repeatedly — degenerated the tree into a deep chain and
-  overflowed the call stack, crashing the app (sooner on Flutter web, where the
-  stack is smaller). The traversal is now iterative (explicit stack), with no
-  depth limit and the same ordering.
+- **Fugue text handler only:** reading a large document no longer risks a stack
+  overflow. The Fugue tree's in-order traversal was recursive, so a long run of
+  consecutive inserts (e.g. repeated pasting) grew a deep chain that overflowed
+  the call stack — sooner on Flutter web. It is now iterative.
 
 ## [3.4.1](https://github.com/MattiaPispisa/crdt/tree/crdt_lf-v3.4.1/packages/crdt_lf)
 

--- a/packages/crdt_lf/CHANGELOG.md
+++ b/packages/crdt_lf/CHANGELOG.md
@@ -1,4 +1,8 @@
-## Unreleased
+## [3.4.2](https://github.com/MattiaPispisa/crdt/tree/crdt_lf-v3.4.2/packages/crdt_lf)
+
+**Date:** 2026-07-21
+
+[compare to previous release](https://github.com/MattiaPispisa/crdt/compare/crdt_lf-v3.4.1...crdt_lf-v3.4.2)
 
 ### Fixed
 

--- a/packages/crdt_lf/CHANGELOG.md
+++ b/packages/crdt_lf/CHANGELOG.md
@@ -1,3 +1,15 @@
+## Unreleased
+
+### Fixed
+
+- Reading a large document no longer risks a stack overflow. The Fugue tree's
+  in-order traversal (behind `value`/`nodes`, and the index rebuild on
+  deserialization) was recursive, so a long run of consecutive inserts — e.g.
+  pasting a big block repeatedly — degenerated the tree into a deep chain and
+  overflowed the call stack, crashing the app (sooner on Flutter web, where the
+  stack is smaller). The traversal is now iterative (explicit stack), with no
+  depth limit and the same ordering.
+
 ## [3.4.1](https://github.com/MattiaPispisa/crdt/tree/crdt_lf-v3.4.1/packages/crdt_lf)
 
 **Date:** 2026-07-20

--- a/packages/crdt_lf/lib/src/algorithm/fugue/tree.dart
+++ b/packages/crdt_lf/lib/src/algorithm/fugue/tree.dart
@@ -86,13 +86,6 @@ class FugueTree<T> {
   ///
   /// Visits the left children, then the node itself, then the right children,
   /// collecting the non-deleted values (different from `⊥`).
-  ///
-  /// Iterative (explicit stack) on purpose: a run of consecutive inserts —
-  /// e.g. pasting a large block — degenerates the tree into a long chain, and
-  /// a recursive walk would overflow the call stack (crashing the whole app,
-  /// sooner on the web where the stack is smaller). Each stack entry is
-  /// `(id, emitSelf)`: `emitSelf == false` expands the node (pushing its
-  /// children and its own emit marker), `emitSelf == true` appends its value.
   List<K> _traverse<K>(
     FugueElementID nodeID,
     K Function(FugueValueNode<T> node) transform,
@@ -396,10 +389,6 @@ class FugueTree<T> {
 
   /// In-order traversal collecting **all** structural nodes except the root
   /// (tombstones included), as parallel id/liveness lists for [_index].
-  ///
-  /// Iterative for the same reason as [_traverse]: a deep tree (a long run of
-  /// consecutive inserts) would overflow the call stack, here while rebuilding
-  /// the index after deserializing a large document.
   void _collectStructuralInOrder(
     FugueElementID nodeID,
     List<FugueElementID> ids,
@@ -547,8 +536,7 @@ class FugueTree<T> {
   }
 }
 
-/// One frame of the explicit-stack in-order traversals in [FugueTree]
-/// ([FugueTree._traverse], [FugueTree._collectStructuralInOrder]).
+/// One frame of the explicit-stack in-order traversals in [FugueTree].
 ///
 /// `emitSelf == false` expands the node (pushing its children and its own
 /// emit frame); `emitSelf == true` visits the node itself.

--- a/packages/crdt_lf/lib/src/algorithm/fugue/tree.dart
+++ b/packages/crdt_lf/lib/src/algorithm/fugue/tree.dart
@@ -82,47 +82,50 @@ class FugueTree<T> {
     return _traverse(_rootID, (node) => node);
   }
 
-  /// Traverses the tree starting from the specified node
+  /// Traverses the tree starting from the specified node.
   ///
-  /// Visits recursively the left children,
-  /// then the node itself, then the right children
-  /// Collects the non-deleted values (different from `⊥`)
+  /// Visits the left children, then the node itself, then the right children,
+  /// collecting the non-deleted values (different from `⊥`).
+  ///
+  /// Iterative (explicit stack) on purpose: a run of consecutive inserts —
+  /// e.g. pasting a large block — degenerates the tree into a long chain, and
+  /// a recursive walk would overflow the call stack (crashing the whole app,
+  /// sooner on the web where the stack is smaller). Each stack entry is
+  /// `(id, emitSelf)`: `emitSelf == false` expands the node (pushing its
+  /// children and its own emit marker), `emitSelf == true` appends its value.
   List<K> _traverse<K>(
     FugueElementID nodeID,
     K Function(FugueValueNode<T> node) transform,
   ) {
     final result = <K>[];
+    final stack = <_TraversalStep>[_TraversalStep(nodeID, emitSelf: false)];
 
-    if (!_nodes.containsKey(nodeID)) {
-      return result;
-    }
+    while (stack.isNotEmpty) {
+      final step = stack.removeLast();
+      final nodeTriple = _nodes[step.id];
+      if (nodeTriple == null) {
+        continue;
+      }
+      final node = nodeTriple.node;
 
-    final nodeTriple = _nodes[nodeID]!;
-    final node = nodeTriple.node;
-    final leftChildren = nodeTriple.leftChildren;
-    final rightChildren = nodeTriple.rightChildren;
+      if (step.emitSelf) {
+        // Visit the node itself if not deleted.
+        final value = node.value;
+        if (value != null) {
+          result.add(transform(FugueValueNode(id: node.id, value: value)));
+        }
+        continue;
+      }
 
-    // Recursively visit left children
-    for (final childID in leftChildren) {
-      result.addAll(_traverse<K>(childID, transform));
-    }
-
-    // Visit the node itself if not deleted
-    final value = node.value;
-    if (value != null) {
-      result.add(
-        transform(
-          FugueValueNode(
-            id: node.id,
-            value: value,
-          ),
-        ),
-      );
-    }
-
-    // Recursively visit right children
-    for (final childID in rightChildren) {
-      result.addAll(_traverse<K>(childID, transform));
+      // Push in reverse so the pop order is: left children, self, then right
+      // children (each child list kept in its own order).
+      for (final childID in nodeTriple.rightChildren.reversed) {
+        stack.add(_TraversalStep(childID, emitSelf: false));
+      }
+      stack.add(_TraversalStep(step.id, emitSelf: true));
+      for (final childID in nodeTriple.leftChildren.reversed) {
+        stack.add(_TraversalStep(childID, emitSelf: false));
+      }
     }
 
     return result;
@@ -393,24 +396,39 @@ class FugueTree<T> {
 
   /// In-order traversal collecting **all** structural nodes except the root
   /// (tombstones included), as parallel id/liveness lists for [_index].
+  ///
+  /// Iterative for the same reason as [_traverse]: a deep tree (a long run of
+  /// consecutive inserts) would overflow the call stack, here while rebuilding
+  /// the index after deserializing a large document.
   void _collectStructuralInOrder(
     FugueElementID nodeID,
     List<FugueElementID> ids,
     List<bool> live,
   ) {
-    final triple = _nodes[nodeID];
-    if (triple == null) {
-      return;
-    }
-    for (final childID in triple.leftChildren) {
-      _collectStructuralInOrder(childID, ids, live);
-    }
-    if (nodeID != _rootID) {
-      ids.add(nodeID);
-      live.add(triple.node.value != null);
-    }
-    for (final childID in triple.rightChildren) {
-      _collectStructuralInOrder(childID, ids, live);
+    final stack = <_TraversalStep>[_TraversalStep(nodeID, emitSelf: false)];
+
+    while (stack.isNotEmpty) {
+      final step = stack.removeLast();
+      final triple = _nodes[step.id];
+      if (triple == null) {
+        continue;
+      }
+
+      if (step.emitSelf) {
+        if (step.id != _rootID) {
+          ids.add(step.id);
+          live.add(triple.node.value != null);
+        }
+        continue;
+      }
+
+      for (final childID in triple.rightChildren.reversed) {
+        stack.add(_TraversalStep(childID, emitSelf: false));
+      }
+      stack.add(_TraversalStep(step.id, emitSelf: true));
+      for (final childID in triple.leftChildren.reversed) {
+        stack.add(_TraversalStep(childID, emitSelf: false));
+      }
     }
   }
 
@@ -527,4 +545,16 @@ class FugueTree<T> {
       _buildTreeString(childID, depth + 1, buffer);
     }
   }
+}
+
+/// One frame of the explicit-stack in-order traversals in [FugueTree]
+/// ([FugueTree._traverse], [FugueTree._collectStructuralInOrder]).
+///
+/// `emitSelf == false` expands the node (pushing its children and its own
+/// emit frame); `emitSelf == true` visits the node itself.
+class _TraversalStep {
+  _TraversalStep(this.id, {required this.emitSelf});
+
+  final FugueElementID id;
+  final bool emitSelf;
 }

--- a/packages/crdt_lf/pubspec.yaml
+++ b/packages/crdt_lf/pubspec.yaml
@@ -4,7 +4,7 @@ homepage: https://mattiapispisa.github.io/
 repository: https://github.com/MattiaPispisa/crdt/tree/main/packages/crdt_lf
 topics: [crdt, local-first, fugue, hlc]
 
-version: 3.4.1
+version: 3.4.2
 
 environment:
   sdk: ">=2.17.0 <4.0.0"

--- a/packages/crdt_lf/test/handler/fugue_text/handler_test.dart
+++ b/packages/crdt_lf/test/handler/fugue_text/handler_test.dart
@@ -990,5 +990,33 @@ void main() {
         expect(reloadedText.value, equals('😀 x 𐐷'));
       });
     });
+
+    test(
+        'a deep tree (many large inserts, e.g. repeated paste) does not '
+        'overflow the stack on read or on reload', () {
+      // Regression: the Fugue tree in-order traversal used to be recursive, so
+      // a long run of consecutive inserts degenerated it into a deep chain and
+      // reading `value` (or rebuilding the index on reload) overflowed the
+      // call stack — crashing a Flutter web app after enough pasting.
+      final doc = CRDTDocument();
+      final text = CRDTFugueTextHandler(doc, 'text');
+      const block = 'the quick brown fox jumps over the lazy dog\n\n';
+      var length = 0;
+      for (var i = 0; i < 600; i++) {
+        text.insert(length, block);
+        length += block.length;
+      }
+
+      // Reading the whole value (in-order traversal) must not overflow.
+      expect(text.value.length, 600 * block.length);
+
+      // Reloading from a snapshot rebuilds the positional index with the same
+      // in-order traversal — must not overflow either.
+      final snapshot = doc.takeSnapshot();
+      final restored = CRDTDocument();
+      final restoredText = CRDTFugueTextHandler(restored, 'text');
+      restored.importSnapshot(snapshot);
+      expect(restoredText.value, equals(text.value));
+    });
   });
 }

--- a/packages/crdt_lf_flutter/CHANGELOG.md
+++ b/packages/crdt_lf_flutter/CHANGELOG.md
@@ -1,3 +1,10 @@
+## Unreleased
+
+### Fixed
+
+- `CrdtTextFieldBuilder`: an edit made next to an identical character no longer slides to the wrong side of
+  that character. The text delta is now anchored to the post-edit caret.
+
 ## [0.2.0+1](https://github.com/MattiaPispisa/crdt/tree/crdt_lf_flutter-v0.2.0+1/packages/crdt_lf_flutter)
 
 **Date:** 2026-07-19

--- a/packages/crdt_lf_flutter/CHANGELOG.md
+++ b/packages/crdt_lf_flutter/CHANGELOG.md
@@ -1,4 +1,8 @@
-## Unreleased
+## [0.2.1](https://github.com/MattiaPispisa/crdt/tree/crdt_lf_flutter-v0.2.1/packages/crdt_lf_flutter)
+
+**Date:** 2026-07-21
+
+[compare to previous release](https://github.com/MattiaPispisa/crdt/compare/crdt_lf_flutter-v0.2.0+1...crdt_lf_flutter-v0.2.1)
 
 ### Fixed
 

--- a/packages/crdt_lf_flutter/lib/src/effects/crdt_text_field.dart
+++ b/packages/crdt_lf_flutter/lib/src/effects/crdt_text_field.dart
@@ -261,7 +261,12 @@ class _CrdtTextFieldBuilderState extends State<CrdtTextFieldBuilder> {
     final handlerText = _handlerText();
     final target = _controller!.text;
 
-    final delta = computeTextDelta(_lastCommittedText, target);
+    // The post-edit caret disambiguates edits inside a run of identical
+    // characters (e.g. a newline typed right before another newline), so the
+    // gesture is recorded where the user actually is, not slid past it.
+    final selection = _controller!.selection;
+    final caret = selection.isCollapsed ? selection.baseOffset : null;
+    final delta = computeTextDelta(_lastCommittedText, target, caret: caret);
     if (delta == null) {
       _lastCommittedText = target;
       return;

--- a/packages/crdt_lf_flutter/lib/src/effects/text_delta.dart
+++ b/packages/crdt_lf_flutter/lib/src/effects/text_delta.dart
@@ -48,9 +48,19 @@ class TextDelta {
 /// snapped so that a UTF-16 surrogate pair is never split between the kept
 /// and the replaced region.
 ///
+/// When the resulting collapsed [caret] (the selection offset *after* the
+/// edit) is known, it disambiguates edits that touch a run of identical
+/// characters: inserting a `\n` right before an existing `\n`, typing a space
+/// before a space, etc. Prefix/suffix trimming alone is ambiguous there — the
+/// two candidate positions produce the same string but a different edit — and
+/// plain greedy trimming slides the edit *past* the caret, attaching the new
+/// characters to the wrong side. Anchoring the edit so it ends at [caret]
+/// keeps it where the user actually typed. Pass `null` (the default) to skip
+/// this, e.g. when mapping a remote change rather than a local gesture.
+///
 /// Non-contiguous edits (which no single editing gesture produces) collapse
 /// into one delta spanning both, which is still correct — just coarser.
-TextDelta? computeTextDelta(String oldText, String newText) {
+TextDelta? computeTextDelta(String oldText, String newText, {int? caret}) {
   if (oldText == newText) {
     return null;
   }
@@ -63,6 +73,20 @@ TextDelta? computeTextDelta(String oldText, String newText) {
   while (start < maxPrefix &&
       oldText.codeUnitAt(start) == newText.codeUnitAt(start)) {
     start++;
+  }
+
+  // Break the identical-run ambiguity toward the caret: the inserted run must
+  // end at [caret], so the kept prefix cannot reach past it. A net insertion
+  // of `k` characters starts `k` before the caret; a deletion/replacement
+  // starts at the caret. We only ever *shorten* the prefix here — the freed
+  // characters fold into the changed region, so the delta stays string-exact
+  // — and then re-derive the suffix below against the corrected boundary.
+  if (caret != null && caret >= 0 && caret <= newLength) {
+    final netInsert = newLength > oldLength ? newLength - oldLength : 0;
+    final cap = caret - netInsert;
+    if (cap < start) {
+      start = cap < 0 ? 0 : cap;
+    }
   }
 
   var endOld = oldLength;

--- a/packages/crdt_lf_flutter/pubspec.lock
+++ b/packages/crdt_lf_flutter/pubspec.lock
@@ -47,7 +47,7 @@ packages:
       path: "../crdt_lf"
       relative: true
     source: path
-    version: "3.4.1"
+    version: "3.4.2"
   crypto:
     dependency: transitive
     description:

--- a/packages/crdt_lf_flutter/pubspec.yaml
+++ b/packages/crdt_lf_flutter/pubspec.yaml
@@ -4,13 +4,13 @@ homepage: https://mattiapispisa.github.io/
 repository: https://github.com/MattiaPispisa/crdt/tree/main/packages/crdt_lf_flutter
 topics: [crdt, local-first, flutter, reactive]
 
-version: 0.2.0+1
+version: 0.2.1
 
 environment:
   sdk: ">=3.0.0 <4.0.0"
 
 dependencies:
-  crdt_lf: ^3.4.0
+  crdt_lf: ^3.4.2
   flutter:
     sdk: flutter
   provider: ^6.0.0

--- a/packages/crdt_lf_flutter/test/crdt_text_field_test.dart
+++ b/packages/crdt_lf_flutter/test/crdt_text_field_test.dart
@@ -170,6 +170,40 @@ void main() {
       expect(controller.text, note.value);
     });
 
+    testWidgets(
+        'records a mid-caret edit next to an identical character on the '
+        'caret side (does not slide past it)', (tester) async {
+      // Regression: typing on the empty line between the fences of
+      // "```dart\n```" used to attach the characters after the closing
+      // newline, because the delta slid across the identical '\n'.
+      final note = CRDTFugueTextHandler(doc, 'note')..insert(0, '```dart\n```');
+      await tester.pumpWidget(host());
+      final controller =
+          tester.widget<TextField>(find.byType(TextField)).controller!;
+
+      // Drive the controller as a real keystroke does (TextField writes the
+      // new value + collapsed caret to its controller, firing the binding).
+      void keystroke(int at, String ch) {
+        controller.value = TextEditingValue(
+          text: controller.text.replaceRange(at, at, ch),
+          selection: TextSelection.collapsed(offset: at + ch.length),
+        );
+      }
+
+      // Caret at the end of line 1 (before the existing '\n'), press Enter.
+      keystroke(7, '\n');
+      await tester.pump();
+
+      // Type on the now-empty middle line.
+      for (final ch in 'hi'.split('')) {
+        keystroke(controller.selection.baseOffset, ch);
+        await tester.pump();
+      }
+
+      expect(controller.text, '```dart\nhi\n```');
+      expect(note.value, '```dart\nhi\n```');
+    });
+
     testWidgets('throws a FlutterError for a non-text handler', (tester) async {
       CRDTListHandler<String>(doc, 'note');
       await tester.pumpWidget(host());

--- a/packages/crdt_lf_flutter/test/text_delta_test.dart
+++ b/packages/crdt_lf_flutter/test/text_delta_test.dart
@@ -46,6 +46,39 @@ void main() {
       expect(delta.inserted, 'a');
     });
 
+    test('anchors an ambiguous insertion to the caret', () {
+      // Enter pressed *before* an existing '\n' (as between the two lines of
+      // a code fence). Without the caret, greedy prefix trimming slides the
+      // insertion past the caret to index 8, attaching the newline to the
+      // wrong side; with the caret (offset 8, after the inserted '\n') the
+      // edit is recorded where the user actually is.
+      const before = '```dart\n```';
+      const after = '```dart\n\n```';
+      expect(
+        computeTextDelta(before, after),
+        const TextDelta(index: 8, deleted: 0, inserted: '\n'),
+      );
+      expect(
+        computeTextDelta(before, after, caret: 8),
+        const TextDelta(index: 7, deleted: 0, inserted: '\n'),
+      );
+    });
+
+    test('anchors an ambiguous deletion to the caret', () {
+      // Backspace removing the *first* of two 'a's: caret ends at 1.
+      expect(
+        computeTextDelta('baab', 'bab', caret: 1),
+        const TextDelta(index: 1, deleted: 1, inserted: ''),
+      );
+    });
+
+    test('a caret leaves an unambiguous edit unchanged', () {
+      expect(
+        computeTextDelta('hello world', 'hello brave world', caret: 12),
+        const TextDelta(index: 6, deleted: 0, inserted: 'brave '),
+      );
+    });
+
     test('never splits a surrogate pair between kept and replaced regions', () {
       // The two emoji share the high surrogate: a naive trim would keep it
       // and replace only the low surrogate, producing lone-surrogate ops.


### PR DESCRIPTION
- stack overflow in recursive fugue traverse
- identical characters lead to an incorrect caret position